### PR TITLE
Draft: FVVAG-493 Prevent form submit by powermail_cond which breaks client sided validation

### DIFF
--- a/Resources/Private/Build/JavaScript/PowermailConditions.js
+++ b/Resources/Private/Build/JavaScript/PowermailConditions.js
@@ -43,7 +43,8 @@ class PowermailConditions {
     }
 
     that.#fieldListener();
-    that.#submitListener();
+    // Wait until https://github.com/in2code-de/powermail_cond/issues/111 is fixed
+    // that.#submitListener();
   }
 
   /**


### PR DESCRIPTION
This is a temporary solution of https://github.com/in2code-de/powermail_cond/issues/111.

* the commit https://github.com/in2code-de/powermail_cond/commit/2727a606a117e9dca28a19676ebc1c9bbec5eb47 "[BUGFIX] Prevent race condition when submitting with focused input" breaks the powermail client sided validation
* it sends the form in any case => bad UX
* comment it out until this gets hopefully fixed

Relevant in v13 (not v12)

Do not merge!